### PR TITLE
non-square VAE tiling

### DIFF
--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -607,6 +607,33 @@ __STATIC_INLINE__ void ggml_tensor_scale_output(struct ggml_tensor* src) {
 
 typedef std::function<void(ggml_tensor*, ggml_tensor*, bool)> on_tile_process;
 
+__STATIC_INLINE__ void
+sd_tiling_calc_tiles(int &num_tiles_dim, float& tile_overlap_factor_dim, int small_dim, int tile_size, const float tile_overlap_factor) {
+
+    int tile_overlap     = (tile_size * tile_overlap_factor);
+    int non_tile_overlap = tile_size - tile_overlap;
+
+    num_tiles_dim = (small_dim - tile_overlap) / non_tile_overlap;
+    int overshoot_dim = ((num_tiles_dim + 1) * non_tile_overlap + tile_overlap) % small_dim;
+
+    if ((overshoot_dim != non_tile_overlap) && (overshoot_dim <= num_tiles_dim * (tile_size / 2 - tile_overlap))) {
+        // if tiles don't fit perfectly using the desired overlap
+        // and there is enough room to squeeze an extra tile without overlap becoming >0.5
+        num_tiles_dim++;
+    }
+
+    tile_overlap_factor_dim = (float)(tile_size * num_tiles_dim - small_dim) / (float)(tile_size * (num_tiles_dim - 1));
+    if (num_tiles_dim <= 2) {
+        if (small_dim <= tile_size) {
+            num_tiles_dim           = 1;
+            tile_overlap_factor_dim = 0;
+        } else {
+            num_tiles_dim           = 2;
+            tile_overlap_factor_dim = (2 * tile_size - small_dim) / (float)tile_size;
+        }
+    }
+}
+
 // Tiling
 __STATIC_INLINE__ void sd_tiling(ggml_tensor* input, ggml_tensor* output, const int scale, const int tile_size, const float tile_overlap_factor, on_tile_process on_processing) {
     output = ggml_set_f32(output, 0);
@@ -629,48 +656,13 @@ __STATIC_INLINE__ void sd_tiling(ggml_tensor* input, ggml_tensor* output, const 
         small_height = input_height;
     }
 
-    int tile_overlap     = (tile_size * tile_overlap_factor);
-    int non_tile_overlap = tile_size - tile_overlap;
+    int num_tiles_x;
+    float tile_overlap_factor_x;
+    sd_tiling_calc_tiles(num_tiles_x, tile_overlap_factor_x, small_width, tile_size, tile_overlap_factor);
 
-    int num_tiles_x = (small_width - tile_overlap) / non_tile_overlap;
-    int overshoot_x = ((num_tiles_x + 1) * non_tile_overlap + tile_overlap) % small_width;
-
-    if ((overshoot_x != non_tile_overlap) && (overshoot_x <= num_tiles_x * (tile_size / 2 - tile_overlap))) {
-        // if tiles don't fit perfectly using the desired overlap
-        // and there is enough room to squeeze an extra tile without overlap becoming >0.5
-        num_tiles_x++;
-    }
-
-    float tile_overlap_factor_x = (float)(tile_size * num_tiles_x - small_width) / (float)(tile_size * (num_tiles_x - 1));
-    if (num_tiles_x <= 2) {
-        if (small_width <= tile_size) {
-            num_tiles_x           = 1;
-            tile_overlap_factor_x = 0;
-        } else {
-            num_tiles_x           = 2;
-            tile_overlap_factor_x = (2 * tile_size - small_width) / (float)tile_size;
-        }
-    }
-
-    int num_tiles_y = (small_height - tile_overlap) / non_tile_overlap;
-    int overshoot_y = ((num_tiles_y + 1) * non_tile_overlap + tile_overlap) % small_height;
-
-    if ((overshoot_y != non_tile_overlap) && (overshoot_y <= num_tiles_y * (tile_size / 2 - tile_overlap))) {
-        // if tiles don't fit perfectly using the desired overlap
-        // and there is enough room to squeeze an extra tile without overlap becoming >0.5
-        num_tiles_y++;
-    }
-
-    float tile_overlap_factor_y = (float)(tile_size * num_tiles_y - small_height) / (float)(tile_size * (num_tiles_y - 1));
-    if (num_tiles_y <= 2) {
-        if (small_height <= tile_size) {
-            num_tiles_y           = 1;
-            tile_overlap_factor_y = 0;
-        } else {
-            num_tiles_y           = 2;
-            tile_overlap_factor_y = (2 * tile_size - small_height) / (float)tile_size;
-        }
-    }
+    int num_tiles_y;
+    float tile_overlap_factor_y;
+    sd_tiling_calc_tiles(num_tiles_y, tile_overlap_factor_y, small_height, tile_size, tile_overlap_factor);
 
     LOG_DEBUG("num tiles : %d, %d ", num_tiles_x, num_tiles_y);
     LOG_DEBUG("optimal overlap : %f, %f (targeting %f)", tile_overlap_factor_x, tile_overlap_factor_y, tile_overlap_factor);

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -1476,13 +1476,13 @@ public:
                     std::string tile_x_str = sd_tile_size_str.substr(0, x_pos);
                     std::string tile_y_str = sd_tile_size_str.substr(x_pos + 1);
                     if (tile_x_str.find('.') != std::string::npos) {
-                        tmp_x = latent_x * get_tile_factor(tile_x_str);
+                        tmp_x = std::round(latent_x * get_tile_factor(tile_x_str));
                     }
                     else {
                         tmp_x = std::stoi(tile_x_str);
                     }
                     if (tile_y_str.find('.') != std::string::npos) {
-                        tmp_y = latent_y * get_tile_factor(tile_y_str);
+                        tmp_y = std::round(latent_y * get_tile_factor(tile_y_str));
                     }
                     else {
                         tmp_y = std::stoi(tile_y_str);
@@ -1491,8 +1491,8 @@ public:
                 else {
                     if (sd_tile_size_str.find('.') != std::string::npos) {
                         float tile_factor = get_tile_factor(sd_tile_size_str);
-                        tmp_x = latent_x * tile_factor;
-                        tmp_y = latent_y * tile_factor;
+                        tmp_x = std::round(latent_x * tile_factor);
+                        tmp_y = std::round(latent_y * tile_factor);
                     }
                     else {
                         tmp_x = tmp_y = std::stoi(sd_tile_size_str);

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -1439,9 +1439,9 @@ public:
                     LOG_WARN("SD_TILE_OVERLAP too low, setting it to 0.0");
                     tile_overlap = 0.0;
                 }
-                else if (tile_overlap > 0.95) {
-                    LOG_WARN("SD_TILE_OVERLAP too high, setting it to 0.95");
-                    tile_overlap = 0.95;
+                else if (tile_overlap > 0.5) {
+                    LOG_WARN("SD_TILE_OVERLAP too high, setting it to 0.5");
+                    tile_overlap = 0.5;
                 }
             } catch (const std::invalid_argument&) {
                 LOG_WARN("SD_TILE_OVERLAP is invalid, keeping the default");

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -1489,6 +1489,18 @@ public:
                 LOG_WARN("OOR");
             }
         }
+        float tile_overlap = 0.5f;
+        const char* SD_TILE_OVERLAP = getenv("SD_TILE_OVERLAP");
+        if (SD_TILE_OVERLAP != nullptr) {
+            std::string sd_tile_overlap_str = SD_TILE_OVERLAP;
+            try {
+                tile_overlap = std::stof(sd_tile_overlap_str);
+            } catch (const std::invalid_argument&) {
+                LOG_WARN("Invalid");
+            } catch (const std::out_of_range&) {
+                LOG_WARN("OOR");
+            }
+        }
         if(!decode){
             // TODO: also use and arg for this one?
             // to keep the compute buffer size consistent
@@ -1505,11 +1517,14 @@ public:
                 if (SD_TILE_SIZE != nullptr) {
                     LOG_INFO("VAE Tile size: %dx%d", tile_size_x, tile_size_y);
                 }
+                if (SD_TILE_OVERLAP != nullptr) {
+                    LOG_INFO("VAE Tile overlap: %.2f", tile_overlap);
+                }
                 // split latent in 32x32 tiles and compute in several steps
                 auto on_tiling = [&](ggml_tensor* in, ggml_tensor* out, bool init) {
                     first_stage_model->compute(n_threads, in, decode, &out);
                 };
-                sd_tiling_non_square(x, result, 8, tile_size_x, tile_size_y, 0.5f, on_tiling);
+                sd_tiling_non_square(x, result, 8, tile_size_x, tile_size_y, tile_overlap, on_tiling);
             } else {
                 first_stage_model->compute(n_threads, x, decode, &result);
             }

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -1427,13 +1427,62 @@ public:
                                                  x->ne[3]);  // channels
         int64_t t0          = ggml_time_ms();
 
-        int tile_size = 32;
+        int tile_size_x = 32;
+        int tile_size_y = 32;
         // TODO: arg instead of env?
         const char* SD_TILE_SIZE = getenv("SD_TILE_SIZE");
         if (SD_TILE_SIZE != nullptr) {
+            // format is AxB, or just A (equivalent to AxA)
+            // A and B can be integers (tile size) or floating point
+            // floating point <= 1 means fraction of the latent dimension
+            // floating point > 1 means number of tiles in that dimension
+            // a single number gets applied to both dimensions
             std::string sd_tile_size_str = SD_TILE_SIZE;
+            size_t x_pos = sd_tile_size_str.find('x');
             try {
-                tile_size = std::stoi(sd_tile_size_str);
+                int tmp_x = tile_size_x, tmp_y = tile_size_y;
+                if (x_pos != std::string::npos) {
+                    std::string tile_x_str = sd_tile_size_str.substr(0, x_pos);
+                    std::string tile_y_str = sd_tile_size_str.substr(x_pos + 1);
+                    if (tile_x_str.find('.') != std::string::npos) {
+                        float tile_factor = std::stof(tile_x_str);
+                        if (tile_factor > 0.0) {
+                            if (tile_factor > 1.0)
+                                tile_factor = 1.0 / tile_factor;
+                            tmp_x = (W / (decode ? 1 : 8)) * tile_factor;
+                        }
+                    }
+                    else {
+                        tmp_x = std::stoi(tile_x_str);
+                    }
+                    if (tile_y_str.find('.') != std::string::npos) {
+                        float tile_factor = std::stof(tile_y_str);
+                        if (tile_factor > 0.0) {
+                            if (tile_factor > 1.0)
+                                tile_factor = 1.0 / tile_factor;
+                            tmp_y = (H / (decode ? 1 : 8)) * tile_factor;
+                        }
+                    }
+                    else {
+                        tmp_y = std::stoi(tile_y_str);
+                    }
+                }
+                else {
+                    if (sd_tile_size_str.find('.') != std::string::npos) {
+                        float tile_factor = std::stof(sd_tile_size_str);
+                        if (tile_factor > 0) {
+                            if (tile_factor > 1.0)
+                                tile_factor = 1.0 / tile_factor;
+                            tmp_x = (W / (decode ? 1 : 8)) * tile_factor;
+                            tmp_y = (H / (decode ? 1 : 8)) * tile_factor;
+                        }
+                    }
+                    else {
+                        tmp_x = tmp_y = std::stoi(sd_tile_size_str);
+                    }
+                }
+                tile_size_x = tmp_x;
+                tile_size_y = tmp_y;
             } catch (const std::invalid_argument&) {
                 LOG_WARN("Invalid");
             } catch (const std::out_of_range&) {
@@ -1443,7 +1492,8 @@ public:
         if(!decode){
             // TODO: also use and arg for this one?
             // to keep the compute buffer size consistent
-            tile_size*=1.30539;
+            tile_size_x*=1.30539;
+            tile_size_y*=1.30539;
         }
         if (!use_tiny_autoencoder) {
             if (decode) {
@@ -1452,11 +1502,14 @@ public:
                 ggml_tensor_scale_input(x);
             }
             if (vae_tiling) {
+                if (SD_TILE_SIZE != nullptr) {
+                    LOG_INFO("VAE Tile size: %dx%d", tile_size_x, tile_size_y);
+                }
                 // split latent in 32x32 tiles and compute in several steps
                 auto on_tiling = [&](ggml_tensor* in, ggml_tensor* out, bool init) {
                     first_stage_model->compute(n_threads, in, decode, &out);
                 };
-                sd_tiling(x, result, 8, tile_size, 0.5f, on_tiling);
+                sd_tiling_non_square(x, result, 8, tile_size_x, tile_size_y, 0.5f, on_tiling);
             } else {
                 first_stage_model->compute(n_threads, x, decode, &result);
             }


### PR DESCRIPTION
Just an experiment to give us even more parameters to play with 🙂

I noticed sd_tiling didn't have anything _forcing_ the tiles to be square, so I've extended SD_TILE_SIZE to support specifying tile sizes directly (like "32x48"), or as a floating-point factor applied to the image dimensions.

The factor thing is interesting, because it can be used to keep the number of tiles in both directions more or less constant, which makes a specific value fast for many different image ratios. For instance, around 15.2 (weird number because I just apply it as-is right now) is just enough to keep it at 4 iterations, which on my card is consistently faster than non-tiled VAE. In hindsight, it probably makes more sense to specify it directly as a number of tiles in each direction, though.